### PR TITLE
Fixed #5

### DIFF
--- a/docassemble/CLAGuardianship/data/questions/affidavit_disclosing_care_or_custody.yml
+++ b/docassemble/CLAGuardianship/data/questions/affidavit_disclosing_care_or_custody.yml
@@ -12,9 +12,9 @@ metadata:
   short title: >-
     Affidavit of Care and Custody
   description: |-
-    The *Affidavit Disclosing Care or Custody Proceeding* is a form you have to file in court cases that involve a child.
+    The *Affidavit Disclosing Care or Custody Proceeding* is a form you have to file in court cases that involve ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" }.
 
-    This form tells the court if there are already any court orders about your child. It also tells the court if any judge is making decisions about your child now.
+    This form tells the court if there are already any court orders about ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" }. It also tells the court if any judge is making decisions about ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" } now.
   authors:
     - Court Forms Online
   allowed_courts:
@@ -366,8 +366,8 @@ fields:
     choices:
       - someone has a 209A (abuse prevention) order
       - someone lives in a domestic violence shelter
-      - someone (other the minor) in danger of abuse
-      - the minor is in danger of abuse
+      - someone (other than ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" }) in danger of abuse
+      - ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" } is in danger of abuse
       - another (legal) reason not listed above
 ---
 template: explain_confidential_addresses
@@ -547,7 +547,7 @@ subquestion: |
   * custody  
   * a 209A restraining order
   * divorce or annulment
-  * child requiring assistance
+  * ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" } requiring assistance
   * child support
   * paternity
   * visitation
@@ -581,7 +581,7 @@ question: |
 subquestion: |
   Include the best information you know. If you’re not sure, it is okay to leave information blank or to write down what you remember.
 
-  Only include information about cases that involve the children.
+  Only include information about cases that involve ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" }.
 
   You will have a chance to add more cases later.
 fields:
@@ -653,8 +653,8 @@ fields:
     js show if: |
       !(val("other_care_custody_proceedings[i].case_status") == "adoption")  && val("other_care_custody_proceedings[i].custody_awarded")
 validation code: |
-  # We don't ask the user to select which child is in the case if
-  # there is only one child. Below code adds the child to the appropriate
+  # We don't ask the user to select which minor is in the case if
+  # there is only one child. Below code adds the minor to the appropriate
   # list so we can write more general code.
   if len(children_of_both) == 1:
     other_care_custody_proceedings[i].children = children_of_both
@@ -662,16 +662,6 @@ validation code: |
 ---
 code: |
   other_care_custody_proceedings[i].other_parties.there_are_any = other_care_custody_proceedings[i].other_party_types["other"]
-
-
-# ---
-# question: |
-#   Who else was involved in this case?
-# subquestion: |
-#   For the ${ordinal(i)} case, ${other_care_custody_proceedings[i]}:
-#   Is there anyone _other than_ you or ${other_parties.familiar()} who
-#   was a party to this case? For example, a grandparent or other parent of the child.
-# yesno: other_care_custody_proceedings[i].other_parties.there_are_any
 ---
 sets:
   - other_care_custody_proceedings[i].other_parties[j].address.address

--- a/docassemble/CLAGuardianship/data/questions/application_for_appointment.yml
+++ b/docassemble/CLAGuardianship/data/questions/application_for_appointment.yml
@@ -23,10 +23,10 @@ continue button field: Application_for_appointment_intro
 question: |
   Application for Appointment of Counsel in a guardianship case of a minor
 subquestion: |
-  If you are the **parent** of a child who is part of a guardianship case,
+  If you are the **parent** of a minor who is part of a guardianship case,
   you can use this interview to ask the court to give you a lawyer.
 
-  This interview will ask you questions about the child, the court case,
+  This interview will ask you questions about ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" }, the court case,
   and your contact information.
 
   There is a fee of $150 to get a lawyer in a guardianship case, but 
@@ -34,7 +34,7 @@ subquestion: |
 ---
 id: Who is this for
 question: |
-  What is the name of the child who is part of the guardianship case?
+  What is the name of the minor who is part of the guardianship case?
 fields:
   - First Name: children[0].name.first
     required: True
@@ -112,7 +112,7 @@ review:
       % endif
   - Edit: children[0].name
     button: |
-      **Child name**:
+      **Minor's name**:
       ${ children[0].name }
   - Edit: users.revisit
     button: |

--- a/docassemble/CLAGuardianship/data/questions/application_for_appointment_standalone.yml
+++ b/docassemble/CLAGuardianship/data/questions/application_for_appointment_standalone.yml
@@ -10,10 +10,10 @@ metadata:
   short title: >-
     Get a lawyer for your guardianship case
   description: |-
-    If you are the **parent** of a child who is part of a guardianship case,
+    If you are the **parent** of a minor who is part of a guardianship case,
     you can use this interview to ask the court to give you a lawyer.
 
-    This interview will ask you questions about the child, the court case,
+    This interview will ask you questions about ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" }, the court case,
     and your contact information.
 
     There is a fee of $150 to get a lawyer in a guardianship case, but 

--- a/docassemble/CLAGuardianship/data/questions/caregiver_authorization_affidavit.yml
+++ b/docassemble/CLAGuardianship/data/questions/caregiver_authorization_affidavit.yml
@@ -104,8 +104,7 @@ continue button field: caregiver_authorization_affidavit_intro
 question: |
   Caregiver Authorization Affidavit or Temporary Agent Affidavit 
 subquestion: |
-  This interview will help you give permission to someone to make decisions about your child (someone under
-  18).
+  This interview will help you give permission to someone to make decisions about ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"your child" }.
   At the end of the interview, you will be able to download and print your **affidavit**,
   which confirms that you are giving permission to someone to take care of your child.
 
@@ -153,7 +152,7 @@ question: |
   Who do you want to give permission to?
 subquestion: |
   You **cannot** name an adult who has had their
-  rights to take care of the child taken away by a court.
+  rights to take care of ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" } taken away by a court.
 fields:
   - code: |
       authorized_persons[0].name_fields()
@@ -212,7 +211,7 @@ id: Information about the caregiver
 question: |
   What best describes you?
 fields:
-  - I am the children's: relationship_to_child
+  - I am ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" }'s: relationship_to_child
     input type: radio
     choices:
       - Parent: parent
@@ -222,10 +221,10 @@ fields:
       **Because you are the legal guardian or custodian**
 
       When you print this document, attach a copy of the court order that gives **you**
-      the right to make decisions about the children.
+      the right to make decisions about ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" }.
     js show if: |
       val("relationship_to_child") == "legal guardian" || val("relationship_to_child") == "legal custodian"
-  - Do the children have another parent who you know and are able to contact?: other_parent
+  - Does ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" } have another parent who you know and are able to contact?: other_parent
     datatype: yesnoradio
     show if:
       variable: relationship_to_child
@@ -272,7 +271,7 @@ subquestion: |
   * There are no court orders in effect that would prohibit me from exercising or conferring the rights and responsibilities that I wish to confer upon the caregiver. 
     (If you are the legal guardian or custodian, attach the court order appointing you.)
   * I am not using this affidavit to circumvent any state or federal law, for the purposes of attendance at a particular school, or to re-confer rights to a caregiver from whom those rights have been removed by a court of law.
-  * I confer these rights and responsibilities freely and knowingly in order to provide for the child(ren) and not as a result of pressure, threats or payments by any person or agency.
+  * I confer these rights and responsibilities freely and knowingly in order to provide for ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" } and not as a result of pressure, threats or payments by any person or agency.
   * I understand that, if the affidavit is amended or revoked, I must provide the amended affidavit or revocation to all parties to whom I have provided this affidavit.
 
 continue button field: acknowledge_what_you_affirm_by_signing
@@ -507,6 +506,4 @@ attachment:
   skip undefined: True
   docx template file: caregiver_authorization_affidavit.docx
   tagged pdf: True
-
-
-
+---

--- a/docassemble/CLAGuardianship/data/questions/consent_to_nomination_by_a_minor_standalone.yml
+++ b/docassemble/CLAGuardianship/data/questions/consent_to_nomination_by_a_minor_standalone.yml
@@ -86,7 +86,7 @@ subquestion: |
   You can use this tool if:
 
   - You are at least 14 and want to choose who will be your guardian.
-  - You have been asked to be a guardian for a child who is at least 14 and you agree **or** disagree to
+  - You have been asked to be a guardian for a minor who is at least 14 and you agree **or** disagree to
     be the guardian.
 
   **Before you get started**:
@@ -311,4 +311,3 @@ attachment:
       - "users1_phone": ${children[0].phone_numbers() }
       - "users1_name": ${children[0].name}
 ---
-

--- a/docassemble/CLAGuardianship/data/questions/customized_screens.yml
+++ b/docassemble/CLAGuardianship/data/questions/customized_screens.yml
@@ -139,7 +139,7 @@ subquestion: |
   The temporary guardian can be the same person as the permanent guardian. 
 
   You can ask for a temporary guardian if waiting for a permanent guardian would risk 
-  **substantial harm** to the child's:
+  **substantial harm** to ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" }'s:
 
   * health,
   * safety, or

--- a/docassemble/CLAGuardianship/data/questions/parent_participate_in_guardianship_case.yml
+++ b/docassemble/CLAGuardianship/data/questions/parent_participate_in_guardianship_case.yml
@@ -4,7 +4,6 @@ include:
   - notice_of_appearance_and_objection.yml
   - parental_consent_to_petition.yml
   - application_for_appointment.yml
-
 ---
 metadata:
   title: >-
@@ -55,7 +54,7 @@ sections:
   - section_starting: Get started
   - section_choice: What do you want to do?
   - section_about_you: About you
-  - section_child: About the child
+  - section_child: About the minor
   - section_guardianship_case: About the guardianship case
   - section_documents: Optional documents
   - review_participate_in_guardianship: Review your answers
@@ -193,13 +192,13 @@ fields:
     field: who_is_asking_to_participate
     datatype: radio
     choices:
-      - The **parent** of the child in the guardianship case: parent
-      - Someone **else** who cares about the child's wellbeing: interested_person
+      - The **parent** of the minor in the guardianship case: parent
+      - Someone **else** who cares about the minor's wellbeing: interested_person
   - label: |
       % if form_filled_by_attorney:
-      And my client's relationship to the child is
+      And my client's relationship to the minor is
       % else:
-      And my relationship to the child is
+      And my relationship to the minor is
       % endif
     field: interested_person_relationship
     show if:
@@ -284,11 +283,7 @@ id: childs name
 sets:
   - children[0].name.first
 question: |
-  % if who_is_asking_to_participate == "interested_person" or form_filled_by_attorney:
-  About the child
-  % else:
-  About your child
-  % endif
+  About the minor
 fields:
   - note: |
       <h2 class="h4">Child's name</h2>
@@ -316,7 +311,7 @@ fields:
     object labeler: court_short_label
     choices: all_courts.filter_courts(allowed_courts)
     under text: |
-      Usually the court in the county where your child lives.
+      Usually the court in the county where ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"your child" } lives.
   - Date filed (optional): file_date
     datatype: date
     required: False
@@ -421,7 +416,7 @@ review:
 
   - Edit: children[0].name.first
     button: |
-      **About the child**
+      **About the minor**
 
       ${ children[0].name_full() }
 
@@ -467,3 +462,4 @@ review:
 ---
 code: |  
   form_filled_by_attorney = bool(len(attorneys))   
+---

--- a/docassemble/CLAGuardianship/data/questions/parental_consent_to_petition.yml
+++ b/docassemble/CLAGuardianship/data/questions/parental_consent_to_petition.yml
@@ -8,10 +8,10 @@ question: |
   Is someone named in the petition to be appointed as a guardian?
 subquestion: |
   In some cases, whoever files the petition to get a guardian for
-  a child will also ask the judge to make a specific person the
+  a minor will also ask the judge to make a specific person the
   guardian.
 
-  They may have named up to 2 people to be the child's guardian.
+  They may have named up to 2 people to be ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" }'s guardian.
 fields:
   - Is someone named as the potential guardian in the petition?: requested_guardians.there_are_any
     datatype: yesnoradio
@@ -20,7 +20,7 @@ id: requested guardian I
 sets:
   - requested_guardians[i].name.first
 question: |
-  Who is the ${ ordinal(i)} person the petitioner asked the judge to make the child's guardian?
+  Who is the ${ ordinal(i)} person the petitioner asked the judge to make ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" }'s guardian?
 subquestion: |
   % if i > 0:
   You have already told us about ${ requested_guardians.complete_elements() }.
@@ -77,14 +77,6 @@ fields:
   - code: |
       children[0].address_fields(country_code=AL_DEFAULT_COUNTRY, default_state=AL_DEFAULT_STATE, show_country=False)
 ---
-# id: minor birthdate
-# question: |
-#   When was ${ children[0].name } born?
-# fields:
-#   - Birthdate: children[0].birthdate
-#     datatype: Birthdate
-
----
 id: temporary_guardianship_duration
 question: |
   Do you understand that if the court appoints a temporary guardian, the guardianship will initially last for 90 days and can be extended for additional 90 day periods if needed?
@@ -94,7 +86,7 @@ fields:
 ---
 id: permanent_guardianship_duration
 question: |
-  Do you understand that if the court appoints a permanent guardian, the guardianship will continue until the child reaches 18 years old, gets married, or the court terminates the guardianship?
+  Do you understand that if the court appoints a permanent guardian, the guardianship will continue until ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" } reaches 18 years old, gets married, or the court terminates the guardianship?
 fields:
   no label: permanent_guardianship_duration
   datatype: yesnoradio

--- a/docassemble/CLAGuardianship/data/questions/petition_for_appointment_of_guardian.yml
+++ b/docassemble/CLAGuardianship/data/questions/petition_for_appointment_of_guardian.yml
@@ -20,11 +20,11 @@ metadata:
   short title: >-
     Minor Guardianship
   description: |-
-    If you are or if you know a child who needs a responsible adult to make decisions
+    If you are or if you know a minor who needs a responsible adult to make decisions
     for them other than their parent or their current guardian, you can use this interview 
     to ask the court to appoint a guardian.
 
-    The guardian can make decisions about the child's health, education, finances, and
+    The guardian can make decisions about the minor's health, education, finances, and
     general welfare.
   tags:
     - "FA-00-00-00-00"
@@ -527,20 +527,6 @@ subquestion: |
 
   Most people take about 20 minutes to finish this interview.
 ---
-# id: who is making petition
-# question: |
-#   % if form_filled_by_attorney:
-#   What best describes your client?
-#   % else:
-#   What best describes you?
-#   % endif
-# fields:
-#   - Choose one: who_is_making_petition
-#     datatype: radio
-#     choices:
-#       - The minor: minor
-#       - Someone interested in the minor's welfare: interested_party
----
 id: choose a court
 question: |
   What court will you file in?
@@ -573,8 +559,8 @@ fields:
       1. The county you live in right now, or
       1. If your parents died, the court serving the county where your parent's estate was **probated** (decided)
       % else:
-      1. The county the child lives in right now, or
-      1. If the child's parents died, the court serving the county where the parent's estate was **probated** (decided)
+      1. The county ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" } lives in right now, or
+      1. If ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" }'s parents died, the court serving the county where the parents' estate was **probated** (decided)
       % endif
 
   - I will file in this court because: court_choice_reason
@@ -587,14 +573,14 @@ fields:
           % if who_is_making_petition == "minor":
           It is the court serving the county where I live
           % else:
-          It is the court serving the county where the child lives
+          It is the court serving the county where ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" } lives
           % endif
         key: minors_county
       - label: |
           % if who_is_making_petition == "minor":
           My parent or parents died and this is the court serving the county where their estate was probated
           % else:
-          The child's parent or parents died and this is the court serving the county where their estate was probated
+          ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"The minor" }'s parent or parents died and this is the court serving the county where their estate was probated
           % endif
         key: will_county
 ---
@@ -602,7 +588,7 @@ id: how many parents
 question: |
   How many parents can you tell us about?
 subquestion: |
-  The judge needs to know about the minor's parents, whether or not they are alive.
+  The judge needs to know about ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" }'s parents, whether or not they are alive.
 
   ${ collapse_template(what_is_a_parent) }
 
@@ -621,12 +607,12 @@ template: what_is_a_parent
 subject: |
   What is a parent?
 content: |
-  A parent is someone who is named on the child's official birth record.
+  A parent is someone who is named on ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" }'s official birth record.
   That includes a birth parent who still has parental rights and an adoptive parent.
 
   When someone is adopted, the birth record is updated with the new parent's name.
 
-  You do not need to list a step parent or a foster parent unless they have legally adopted the child.
+  You do not need to list a step parent or a foster parent unless they have legally adopted ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" }.
 ---
 id: parent basic information
 sets:
@@ -903,7 +889,7 @@ subquestion: |
   (opens in a new tab).
 
   When the guardian is for a minor, the surety requirement is often waived, or skipped.
-  This is because the guardian does not have control over the minor's money or property.
+  This is because the guardian does not have control over ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" }'s money or property.
 
   You can ask the judge to skip the surety requirement now.
 fields:
@@ -971,12 +957,12 @@ template: what_is_primary_care_or_custody
 subject: |
   What does **primary care or custody** mean?
 content: |
-  "Primary care or custody" means you are one of the people who takes care of a child 
+  "Primary care or custody" means you are one of the people who takes care of ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" } 
   most of the time. You make big decisions for them and handle their daily needs like meals, 
   a place to live, and keeping them safe.
 
   A paid babysitter doesn't have primary care or custody. 
-  They are only helping for a short time and aren't responsible for all of the child's needs.
+  They are only helping for a short time and aren't responsible for all of ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" }'s needs.
 ---
 id: other custodian information
 sets:
@@ -1092,9 +1078,9 @@ question: |
   Does ${ requested_guardians[i].name } have priority for appointment?
 subquestion: |
   In order to have priority for appointment as a guardian, a person must have been nominated
-  by the minor **and** the minor must be at least 14 years old.
+  by ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" } **and** ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" } must be at least 14 years old.
 
-  If you select 'Yes', you must attach a copy of the minor's nomination to this Petition.
+  If you select 'Yes', you must attach a copy of ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" }'s nomination to this Petition.
 fields:
   - no label: requested_guardians[i].has_priority_appointment
     datatype: yesnoradio
@@ -1273,11 +1259,11 @@ subject: |
   Why does the judge need to know?
 content: |
   A guardian for a minor usually cannot make decisions
-  about the child's property unless they are also appointed
+  about ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" }'s property unless they are also appointed
   as a **conservator**. But the judge still needs to know
-  about things that the minor owns.
+  about things that ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" } owns.
 
-  If the minor owns a lot of valuable things, usually more than
+  If ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" } owns a lot of valuable things, usually more than
   $5,000 worth, the judge may decide that the guardian needs
   to pay or guarantee a bond to the court.
 ---

--- a/docassemble/CLAGuardianship/data/questions/petition_for_removal_of_guardian.yml
+++ b/docassemble/CLAGuardianship/data/questions/petition_for_removal_of_guardian.yml
@@ -181,7 +181,7 @@ subquestion: |
   
   You can use this form to end the guardianship or to replace the guardian if:
 
-    * you or a child you know has a court-appointed guardian, **and** 
+    * you or a minor you know has a court-appointed guardian, **and** 
     * you have a reason for the guardian to be removed or replaced.
 
   You will need to explain why the guardian should be removed or replaced.
@@ -572,17 +572,6 @@ fields:
   - Do you want to find out if you qualify for a fee waiver?: wants_fee_waiver
     datatype: yesnoradio
 ---
-# id: petitioners
-# question: |
-#   Who is asking to change or remove the guardian?
-# fields:
-#   - I am: who_is_making_petition
-#     datatype: radio
-#     choices:
-#       - The minor's parent(s): parent
-#       - The minor: minor
-#       - Someone interested in the minor's welfare: interested_party
----
 id: relationship to minor
 question: |
   What is
@@ -643,7 +632,7 @@ fields:
     maxlength: 25
     required: False
     help: |
-      If there is already a case for the guardianship of the minor, the docket number will written on the court papers. If you
+      If there is already a case for the guardianship of ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" }, the docket number will written on the court papers. If you
       don't have a docket number, or can't find one, you can leave this blank.
 ---
 id: requested_guardians information

--- a/docassemble/CLAGuardianship/data/questions/temporary_guardian.yml
+++ b/docassemble/CLAGuardianship/data/questions/temporary_guardian.yml
@@ -112,7 +112,7 @@ subquestion: |
   (opens in a new tab).
 
   When the guardian is for a minor, the surety requirement is often waived, or skipped.
-  This is because the guardian does not have control over the minor's money or property.
+  This is because the guardian does not have control over ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" }'s money or property.
 
   You can ask the judge to skip the surety requirement now.
 fields:


### PR DESCRIPTION
- Fixed #5 - replaced instances of "the minor" with the familiar form of the minor's name.
- Included conditional logic that defaults to "the minor" whenever there's no child object yet: `${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" }`
- Also fixed #11 - replaced relevant instances of "child" with the same logic. In some cases, "the child" was replaced with "the minor", such as question screens that gather the minor's name.
- Removed some blocks of code that had been commented out and were no longer in use.