### PR TITLE
Added help text in collapse template

### DIFF
--- a/docassemble/CLAGuardianship/data/questions/petition_for_appointment_of_guardian.yml
+++ b/docassemble/CLAGuardianship/data/questions/petition_for_appointment_of_guardian.yml
@@ -1507,7 +1507,7 @@ content: |
   In some cases, you may need to **request special permission for ${ children[0].familiar() } to travel** with the proposed guardian, whether that is yourself or someone else. For example, this request should be included if the guardian:
 
   * Lives in a different state than ${ children[0].familiar() } and is planning to have ${ children[0].familiar() } move in with them.
-  * Plans to travel with ${ children[0].familiar() } outside the US for any reason, such as visitng parents or relatives that live outside the country.
+  * Plans to travel with ${ children[0].familiar() } outside the US for any reason, such as visiting parents or relatives that live outside the country.
   * Wants to get ${ children[0].familiar() } a passport, even if they don't plan on doing any immediate traveling with ${ children[0].familiar() }.
 
   **If any of the above are true**, you can select **Yes** and enter a request in the box below, asking the court to not prohibit the guardian from moving ${ children[0].familiar() } outside of MA.

--- a/docassemble/CLAGuardianship/data/questions/petition_for_appointment_of_guardian.yml
+++ b/docassemble/CLAGuardianship/data/questions/petition_for_appointment_of_guardian.yml
@@ -1510,7 +1510,7 @@ content: |
   * Plans to travel with ${ children[0].familiar() } outside the US for any reason, such as visiting parents or relatives that live outside the country.
   * Wants to get ${ children[0].familiar() } a passport, even if they do not plan on doing any immediate traveling with ${ children[0].familiar() }.
 
-  **If any of the above are true**, you can select **Yes** and enter a request in the box below, asking the court to not prohibit the guardian from moving ${ children[0].familiar() } outside of MA.
+  **If any of the above are true**, you can select **Yes** and write why you need the court to allow the guardian to move ${ children[0].familiar() } outside of Massachusetts.
   
   **If the guardian wants to make this request at a later time**, they will need to file either a *General Probate Petition* or *Complaint for Modification*.
 ---

--- a/docassemble/CLAGuardianship/data/questions/petition_for_appointment_of_guardian.yml
+++ b/docassemble/CLAGuardianship/data/questions/petition_for_appointment_of_guardian.yml
@@ -1508,7 +1508,7 @@ content: |
 
   * Lives in a different state than ${ children[0].familiar() } and is planning to have ${ children[0].familiar() } move in with them.
   * Plans to travel with ${ children[0].familiar() } outside the US for any reason, such as visiting parents or relatives that live outside the country.
-  * Wants to get ${ children[0].familiar() } a passport, even if they don't plan on doing any immediate traveling with ${ children[0].familiar() }.
+  * Wants to get ${ children[0].familiar() } a passport, even if they do not plan on doing any immediate traveling with ${ children[0].familiar() }.
 
   **If any of the above are true**, you can select **Yes** and enter a request in the box below, asking the court to not prohibit the guardian from moving ${ children[0].familiar() } outside of MA.
   

--- a/docassemble/CLAGuardianship/data/questions/petition_for_appointment_of_guardian.yml
+++ b/docassemble/CLAGuardianship/data/questions/petition_for_appointment_of_guardian.yml
@@ -1504,7 +1504,7 @@ template: traveling_with_minor_request
 subject: |
   Is the guardian planning to travel with ${ children[0].familiar() } or have them move to another state?
 content: |
-  In some cases, you may need to **request special permission for ${ children[0].familiar() } to travel** with the proposed guardian, whether that's yourself or someone else. For example, this request should be included if the guardian:
+  In some cases, you may need to **request special permission for ${ children[0].familiar() } to travel** with the proposed guardian, whether that is yourself or someone else. For example, this request should be included if the guardian:
 
   * Lives in a different state than ${ children[0].familiar() } and is planning to have ${ children[0].familiar() } move in with them.
   * Plans to travel with ${ children[0].familiar() } outside the US for any reason, such as visitng parents or relatives that live outside the country.

--- a/docassemble/CLAGuardianship/data/questions/petition_for_appointment_of_guardian.yml
+++ b/docassemble/CLAGuardianship/data/questions/petition_for_appointment_of_guardian.yml
@@ -1487,6 +1487,8 @@ subquestion: |
   If there is something else you need to ask the court on the
   Petition for Guardianship, you can ask it here.
 
+  ${ collapse_template(traveling_with_minor_request) }
+
   This is optional.
 fields:
   - I have another request for the court: wants_additional_request
@@ -1497,6 +1499,20 @@ fields:
     show if:
       variable: wants_additional_request
       is: True
+---
+template: traveling_with_minor_request
+subject: |
+  Is the guardian planning to travel with ${ children[0].familiar() } or have them move to another state?
+content: |
+  In some cases, you may need to **request special permission for ${ children[0].familiar() } to travel** with the proposed guardian, whether that's yourself or someone else. For example, this request should be included if the guardian:
+
+  * Lives in a different state than ${ children[0].familiar() } and is planning to have ${ children[0].familiar() } move in with them.
+  * Plans to travel with ${ children[0].familiar() } outside the US for any reason, such as visitng parents or relatives that live outside the country.
+  * Wants to get ${ children[0].familiar() } a passport, even if they don't plan on doing any immediate traveling with ${ children[0].familiar() }.
+
+  **If any of the above are true**, you can select **Yes** and enter a request in the box below, asking the court to not prohibit the guardian from moving ${ children[0].familiar() } outside of MA.
+  
+  **If the guardian wants to make this request at a later time**, they'll need to file either a *General Probate Peition* or *Complaint for Modification*.
 ---
 id: preview petition_for_appointment_of_guardian
 question: |

--- a/docassemble/CLAGuardianship/data/questions/petition_for_appointment_of_guardian.yml
+++ b/docassemble/CLAGuardianship/data/questions/petition_for_appointment_of_guardian.yml
@@ -1512,7 +1512,7 @@ content: |
 
   **If any of the above are true**, you can select **Yes** and enter a request in the box below, asking the court to not prohibit the guardian from moving ${ children[0].familiar() } outside of MA.
   
-  **If the guardian wants to make this request at a later time**, they'll need to file either a *General Probate Peition* or *Complaint for Modification*.
+  **If the guardian wants to make this request at a later time**, they will need to file either a *General Probate Petition* or *Complaint for Modification*.
 ---
 id: preview petition_for_appointment_of_guardian
 question: |


### PR DESCRIPTION
- Fixed #135 by adding help text in collapse template. The help text addresses all of Carolin's points about needing special permission to have the minor travel, move states, or get a passport.

![Screenshot 2025-05-23 at 4 04 15 PM](https://github.com/user-attachments/assets/cd4546dc-9bd9-490f-b574-60064d5ef8ac)