### PR TITLE
Added info screen regading minor's consent form

### DIFF
--- a/docassemble/CLAGuardianship/data/questions/consent_to_nomination_by_a_minor.yml
+++ b/docassemble/CLAGuardianship/data/questions/consent_to_nomination_by_a_minor.yml
@@ -54,6 +54,20 @@ fields:
   - ${ children[0].familiar() } agrees: petitioner_has_minor_consent
     datatype: yesnomaybe
 ---
+id: explain minor consent
+question: |
+  You may need to take more steps to include ${ children[0].familiar() }'s consent form in your petition!
+subquestion: |
+  **If ${ children[0].familiar() } is older than 14**, they'll need to **sign and notarize** the consent form, **regardless of whether they agree or not**. Otherwise, the court will likely not accept the form.
+
+  You'll need to file an additional **motion waiving the consent form requirements** if ${ children[0].familiar() }:
+  
+  * Can't get the form notarized because they don't have the proper ID 
+  * Refuses to sign the form
+  * Is unable to sign the form because of a disability or other limitation
+
+continue button field: explain_minor_consent
+---
 # ALDocument objects specify the metadata for each template
 objects:
   - consent_to_nomination_by_a_minor_attachment: ALDocument.using(title="Consent to Appointment by Minor", filename="consent_to_nomination_by_a_minor", has_addendum=False, )

--- a/docassemble/CLAGuardianship/data/questions/consent_to_nomination_by_a_minor.yml
+++ b/docassemble/CLAGuardianship/data/questions/consent_to_nomination_by_a_minor.yml
@@ -58,7 +58,8 @@ id: explain minor consent
 question: |
   You may need to take more steps to include ${ children[0].familiar() }'s consent form in your petition!
 subquestion: |
-  **If ${ children[0].familiar() } is older than 14**, they'll need to **sign and notarize** the consent form, **regardless of whether they agree or not**. Otherwise, the court will likely not accept the form.
+  **If ${ children[0].familiar() } is older than 14**, most judges will require them to consent before they appoint a guardian. To accept, ${ children[0].familiar() } will need to **sign and notarize** the consent form.
+```0
 
   You'll need to file an additional **motion waiving the consent form requirements** if ${ children[0].familiar() }:
   

--- a/docassemble/CLAGuardianship/data/questions/petition_for_appointment_of_guardian.yml
+++ b/docassemble/CLAGuardianship/data/questions/petition_for_appointment_of_guardian.yml
@@ -392,7 +392,8 @@ code: |
       requested_guardians.there_are_any = True
     else:
       requested_guardians.there_are_any = False
-      petitioner_has_minor_consent 
+      petitioner_has_minor_consent
+      explain_minor_consent 
   elif (who_is_making_petition == "minor"):
     requested_guardians.there_are_any = True
 


### PR DESCRIPTION
- Fixed #132 by adding info screen immediately after the petitioner_has_minor_consent screen, based on points mentioned in Carolin's feedback:

![Screenshot 2025-05-23 at 5 19 44 PM](https://github.com/user-attachments/assets/2385ed62-f035-431a-affb-aa58c7aada27)
