### PR TITLE
Edited subquestion language regarding required fields

### DIFF
--- a/docassemble/CLAGuardianship/data/questions/affidavit_disclosing_care_or_custody.yml
+++ b/docassemble/CLAGuardianship/data/questions/affidavit_disclosing_care_or_custody.yml
@@ -558,7 +558,7 @@ need: DCF
 question: |
   Tell us about the ${ordinal(i)} case involving ${comma_and_list(children_of_both, and_string=word("or"))}
 subquestion: |
-  Include the best information you know. If you’re not sure, it is okay to leave information blank or to write down what you remember.
+  Include the best information you know. You can skip sections *without* a <span style="color: red;">red asterisk</span> (<span style="color: red;">*</span>) if you don't know or remember the answer. 
 
   Only include information about cases that involve ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" }.
 


### PR DESCRIPTION
- Fixed #136 by editing subquestion language to clarify that sections without the red asterisk can be skipped if needed. Added colorized text to further help user understanding.

![Screenshot 2025-05-25 at 3 59 15 PM](https://github.com/user-attachments/assets/8422f40b-4158-4758-b07b-5988bf484c38)