### PR TITLE
Removed code line that included children when gathering additional_parties

### DIFF
--- a/docassemble/CLAGuardianship/data/questions/customized_screens.yml
+++ b/docassemble/CLAGuardianship/data/questions/customized_screens.yml
@@ -84,10 +84,7 @@ code: |
   # affidavit and the petition.
   # user = petitioner in the petition, and
   # user should be "child" in the military affidavit  
-  if who_is_making_petition == "minor":
-    additional_parties = ALPeopleList(elements=set(parent for parent in parents if not parent.is_deceased).union(other_custodians))
-  else:
-    additional_parties = ALPeopleList(elements=set(parent for parent in parents if not parent.is_deceased).union(children + other_custodians))
+  additional_parties = ALPeopleList(elements=set(parent for parent in parents if not parent.is_deceased).union(other_custodians))
 ---
 code: |
   military_affidavit_case_name = f"In the Interests of { children[0].name_full() }"

--- a/docassemble/CLAGuardianship/data/questions/petition_for_removal_of_guardian.yml
+++ b/docassemble/CLAGuardianship/data/questions/petition_for_removal_of_guardian.yml
@@ -1396,5 +1396,5 @@ code: |
   if who_is_making_petition == "minor":
     additional_parties = ALPeopleList(elements=set(guardians + responsible_parents))
   else:
-    additional_parties = ALPeopleList(elements=guardians.union(children + guardians))
+    additional_parties = ALPeopleList(elements=guardians)
 ---


### PR DESCRIPTION
- Fixed #142 by editing code block that assembled `additional_parties` in customized_screens.yml. Removed lines that include `children` when the `who_is_making_petition == "minor"`.

![Screenshot 2025-05-26 at 10 00 30 PM](https://github.com/user-attachments/assets/217e3737-e9b4-4e3e-b134-d77f9426fa6f)
