### PR TITLE
Re-drafted explanatory language on sureties

### DIFF
--- a/docassemble/CLAGuardianship/data/questions/petition_for_appointment_of_guardian.yml
+++ b/docassemble/CLAGuardianship/data/questions/petition_for_appointment_of_guardian.yml
@@ -1023,20 +1023,12 @@ id: sureties waiver
 question: |
   Waiving the **surety** requirement
 subquestion: |
-  When a judge appoints a guardian, they require the guardian to sign a **bond**
-  to the court and name someone as a **surety**. The bond is a personal guarantee. 
-  It is a promise that the guardian will manage the money and property of the ward responsibly.
-
-  The **surety** is a person who promises to pay the court if the guardian does not manage the money
-  or property the way that they should. The surety can be someone other than the guardian.
+  ${ collapse_template(surety_explanation) }
 
   [More about surety bonds](https://www.masslegalhelp.org/children-and-families/guardians/court-appointment)
   (opens in a new tab).
 
-  When the guardian is for a minor, the surety requirement is often waived, or skipped.
-  This is because the guardian does not have control over ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" }'s money or property.
-
-  You can ask the judge to skip the surety requirement now.
+  **If you don't think a surety will be needed**, you can ask the judge to skip the surety requirement below.
 fields:
   - I want permission to skip the **surety** requirement: wants_sureties_waiver
     datatype: yesnoradio

--- a/docassemble/CLAGuardianship/data/questions/shared.yml
+++ b/docassemble/CLAGuardianship/data/questions/shared.yml
@@ -126,7 +126,24 @@ fields:
       - The minor's parent(s): parent
         show if: guardian_removal
       - Someone interested in the minor's welfare: interested_party
---- 
+---
+template: surety_explanation
+subject: |
+  What is a surety and when is one required?
+content: |
+  **What is a surety?**
+
+  When a judge picks a new guardian for a minor, that person has to promise to take good care of the minor's money and property. 
+  Sometimes, the guardian needs to also choose someone else that agrees to pay the court back if the minor's money or property are not managed well. **This person is called a surety**. 
+
+  **When is a surety needed?**
+
+  Sureties are **not usually required**, since most minors do not have money or property to be managed.
+  In these cases, **the court will likely waive (or skip) the requirement**.
+
+  However, **if the minor *does* have money or property**, a surety will likely be needed. 
+  For example, this can happen when the minor has inherited money or property from a relative that passed away. 
+---
 #################### Question Blocks End #####################
 ---
 #################### Attachment Blocks Start #####################
@@ -181,3 +198,4 @@ terms:
 validation code: |
   if not acknowledged_information_use:
     validation_error("You must accept the terms of use to continue.", field="acknowledged_information_use")
+---

--- a/docassemble/CLAGuardianship/data/questions/temporary_guardian.yml
+++ b/docassemble/CLAGuardianship/data/questions/temporary_guardian.yml
@@ -100,20 +100,12 @@ id: sureties waiver
 question: |
   Waiving the **surety** requirement
 subquestion: |
-  When a judge appoints a guardian, they require the guardian to sign a **bond**
-  to the court and name someone as a **surety**. The bond is a personal guarantee. 
-  It is a promise that the guardian will manage the money and property of the ward responsibly.
-
-  The **surety** is a person who promises to pay the court if the guardian does not manage the money
-  or property the way that they should. The surety can be someone other than the guardian.
+  ${ collapse_template(surety_explanation) }
 
   [More about surety bonds](https://www.masslegalhelp.org/children-and-families/guardians/court-appointment)
   (opens in a new tab).
 
-  When the guardian is for a minor, the surety requirement is often waived, or skipped.
-  This is because the guardian does not have control over ${ children[0].familiar() if len(children.complete_elements()) > 0 else f"the minor" }'s money or property.
-
-  You can ask the judge to skip the surety requirement now.
+  **If you don't think a surety will be needed**, you can ask the judge to skip the surety requirement below.
 fields:
   - I want permission to skip the **surety** requirement: wants_sureties_waiver
     datatype: yesnoradio


### PR DESCRIPTION
Fix #133 

- Re-drafted explanatory language explaining sureties and placed it inside a collapse template
- Included new collapse template explanation in `temporary_guardian.yml` and `petition_for_appointment_of_guardian.yml`