### PR TITLE
140 temp guardians

### DIFF
--- a/docassemble/CLAGuardianship/data/questions/customized_screens.yml
+++ b/docassemble/CLAGuardianship/data/questions/customized_screens.yml
@@ -177,20 +177,14 @@ sets:
 id: same guardian
 question: |
   Who do you want to name as the ${ ordinal(i) } temporary guardian?
-subquestion: |
-  % if i == 0:
-  You can name the same person as the permanent guardian, or you can
-  name someone else.
-  % endif
 fields:
-  - Someone already named: requested_temporary_guardians[i]
+  - You can choose from among the following people included in the petition: requested_temporary_guardians[i]
     datatype: object_radio
     choices:
-      - requested_guardians if ((not petitioner_requesting_guardianship) or (not bio_parents_can_resume_responsibilities)) else []
+      - requested_guardians if len(requested_guardians.complete_elements()) > 0 else []
       - users if petitioner_requesting_guardianship else []
     exclude:
       - requested_temporary_guardians.complete_elements()
-    none of the above: Someone else
+    none of the above: False
     disable others: True
-  - code: |
-      requested_temporary_guardians[i].name_fields()
+---

--- a/docassemble/CLAGuardianship/data/questions/petition_for_appointment_of_guardian.yml
+++ b/docassemble/CLAGuardianship/data/questions/petition_for_appointment_of_guardian.yml
@@ -229,8 +229,9 @@ code: |
   # if requested_guardians.there_are_any:
   #   requested_guardians.gather()
 
-  if requested_temporary_guardians.there_are_any:
-    interview_order_temporary_guardian
+  if petitioner_requesting_guardianship or len(requested_guardians.complete_elements()) > 0:
+    if requested_temporary_guardians.there_are_any:
+      interview_order_temporary_guardian
   wants_sureties_waiver
   interview_order_bond
 

--- a/docassemble/CLAGuardianship/data/questions/petition_for_removal_of_guardian.yml
+++ b/docassemble/CLAGuardianship/data/questions/petition_for_removal_of_guardian.yml
@@ -510,12 +510,7 @@ code: |
   user_ask_role = "plaintiff"
 ---
 code: |
-  motion_temporary_guardian_attachment.enabled = False
-  
-  if requested_guardians.there_are_any:
-    if requested_temporary_guardians.there_are_any:
-      motion_temporary_guardian_attachment.enabled = True 
-  
+  motion_temporary_guardian_attachment.enabled = requested_guardians.there_are_any and requested_temporary_guardians.there_are_any
   set_temp_guardian_doc = True
 ---
 #################### Object Blocks End #####################

--- a/docassemble/CLAGuardianship/data/questions/petition_for_removal_of_guardian.yml
+++ b/docassemble/CLAGuardianship/data/questions/petition_for_removal_of_guardian.yml
@@ -223,6 +223,8 @@ code: |
     if requested_temporary_guardians.there_are_any:
       interview_order_temporary_guardian
 
+  set_temp_guardian_doc
+
   interview_order_petition_for_removal_of_guardian = True
 ---
 ###################### Main order ######################
@@ -506,6 +508,15 @@ code: |
 ---
 code: |
   user_ask_role = "plaintiff"
+---
+code: |
+  motion_temporary_guardian_attachment.enabled = False
+  
+  if requested_guardians.there_are_any:
+    if requested_temporary_guardians.there_are_any:
+      motion_temporary_guardian_attachment.enabled = True 
+  
+  set_temp_guardian_doc = True
 ---
 #################### Object Blocks End #####################
 ---

--- a/docassemble/CLAGuardianship/data/questions/petition_for_removal_of_guardian.yml
+++ b/docassemble/CLAGuardianship/data/questions/petition_for_removal_of_guardian.yml
@@ -219,8 +219,9 @@ code: |
     if requested_guardians.there_are_any: 
       requested_guardians.gather()
   
-  if requested_temporary_guardians.there_are_any:
-    interview_order_temporary_guardian
+  if requested_guardians.there_are_any:
+    if requested_temporary_guardians.there_are_any:
+      interview_order_temporary_guardian
 
   interview_order_petition_for_removal_of_guardian = True
 ---


### PR DESCRIPTION
Fix #140 

- Removed option to enter 'Someone else' from temporary guardian screen; user can now only select from people already included in the petition

- For appointment interview, temp guardians will only be gathered if the user has added requested guardians, or is themselves requesting to be made guardian.

- For removal interview, added code block that prevents the temp guardian document from generating, unless temp guardians have been added.